### PR TITLE
Splendor gem luck value correction

### DIFF
--- a/kubejs/data/apotheosis/gems/core/splendor.json
+++ b/kubejs/data/apotheosis/gems/core/splendor.json
@@ -24,7 +24,7 @@
                 "flawed": 1.5,
                 "normal": 2.0,
                 "flawless": 2.5,
-                "perfect": 2.0
+                "perfect": 3.0
             }
         },
         {


### PR DESCRIPTION
Perfect splendor gem luck value from 2 -> 3 
because flawless has value 2.5

https://github.com/Rodrigo816/create-chronicles-the-endventure/issues/1#issue-3271248571